### PR TITLE
build: fix deprecated function vergen::gen warning

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,15 +1,15 @@
 extern crate reqwest;
 extern crate vergen;
 
-use vergen::ConstantsFlags;
-
 fn main() {
-    // Generate flags about build information
-    let flags = ConstantsFlags::BUILD_TIMESTAMP
-        | ConstantsFlags::SEMVER
-        | ConstantsFlags::BUILD_DATE
-        | ConstantsFlags::SHA_SHORT;
-    vergen::gen(flags).expect("Unable to generate the cargo keys!");
+    // Configure vergen
+    let mut config = vergen::Config::default();
+    *config.build_mut().semver_mut() = true;
+    *config.build_mut().timestamp_mut() = true;
+    *config.build_mut().kind_mut() = vergen::TimestampKind::DateOnly;
+    *config.git_mut().sha_kind_mut() = vergen::ShaKind::Short;
+
+    vergen::vergen(config).expect("Unable to generate the cargo keys!");
 
     // Download vue file
     let vue_url = "https://unpkg.com/vue@3.0.5/dist/vue.global.js";


### PR DESCRIPTION
This commit fixes the warning: "use of deprecated function `vergen::gen`:
Please use the `vergen` function instead"