### PR TITLE
src: html: Use a default endpoint when not set.

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -136,7 +136,7 @@
                         "name": stream.name,
                         "source": stream.source,
                         "stream_information": {
-                            "endpoints": stream.endpoints.split(','),
+                            "endpoints": stream.endpoints ? stream.endpoints.split(',') : ["udp://0.0.0.0:5600"],
                             "configuration": {
                                 "encode": stream.configuration.encode,
                                 "height": Number(stream.configuration.size.height),


### PR DESCRIPTION
Fixes #7 and #8.