### PR TITLE
src: mavlink: Remove trailing null bytes before parsing the control id.

### DIFF
--- a/src/mavlink/mavlink_camera.rs
+++ b/src/mavlink/mavlink_camera.rs
@@ -349,7 +349,7 @@ fn receive_message_loop(
                         }
 
                         let param_id: String = param_ext_set.param_id.iter().collect();
-                        let control_id = param_id.parse::<u64>();
+                        let control_id = param_id.trim_end_matches(char::from(0)).parse::<u64>();
 
                         let bytes: Vec<u8> =
                             param_ext_set.param_value.iter().map(|c| *c as u8).collect();


### PR DESCRIPTION
Should fix #33

## Details about the problem:

The function that does the was getting `"9963776\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}"` in the `param_id` when changing the _Brightness_ control on QGC, and the code is trying to parse this entire string as a `u64`, which fails.

## Solution:
One quick solution is to remove the trailing \0 before the parsing, as shown in [this playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=1ff202343838bd5d4dd01a03cf1e8ab3).
