### PR TITLE
src: html: Make the frontend tolerate null extended_configuration.

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -64,7 +64,14 @@
                         <h3>Name: {{ stream.video_and_stream.name }}</h3>
                     </div>
                     <div>
-                        <p>Video: {{ stream.video_and_stream.stream_information.configuration.encode }} {{ stream.video_and_stream.stream_information.configuration.width }}x{{ stream.video_and_stream.stream_information.configuration.height }} @ {{ stream.video_and_stream.stream_information.configuration.frame_interval.denominator / stream.video_and_stream.stream_information.configuration.frame_interval.numerator}} FPS, Thermal: {{stream.video_and_stream.stream_information.extended_configuration.thermal}}</p>
+                        <p>Video: {{ stream.video_and_stream.stream_information.configuration.encode }} {{
+                            stream.video_and_stream.stream_information.configuration.width }}x{{
+                            stream.video_and_stream.stream_information.configuration.height }} @ {{
+                            stream.video_and_stream.stream_information.configuration.frame_interval.denominator /
+                            stream.video_and_stream.stream_information.configuration.frame_interval.numerator}} FPS,
+                            Thermal: {{stream.video_and_stream.stream_information.extended_configuration?.thermal ??
+                            false}}
+                        </p>
                     </div>
                     <div>
                         <button type="button" v-on:click="deleteStream(stream.video_and_stream.name)">Delete stream</button>
@@ -234,7 +241,7 @@
                             width: this.stream.video_and_stream.stream_information.configuration.width
                         }
                         this.stream_setting.configuration.interval = this.stream.video_and_stream.stream_information.configuration.frame_interval
-                        this.stream_setting.extended_configuration.thermal = this.stream.video_and_stream.stream_information.extended_configuration.thermal
+                        this.stream_setting.extended_configuration.thermal = Boolean(this.stream.video_and_stream.stream_information.extended_configuration?.thermal)
                         this.stream_setting.configuration.endpoints = this.stream.video_and_stream.stream_information.endpoints ?
                             this.stream.video_and_stream.stream_information.endpoints.join(", ") : ""
                     },


### PR DESCRIPTION
Fix #48.

Details:

We were accessing the "extended_configuration" filed without checking its existence, which will cause invalid access in the case of loading an older configuration.

I couldn't get rid of the uncoherent "null" from being shown on the stream description, but at least it is loading normally with this patch, considering thermal as "false" when "extended_configuration" is "null".

![image](https://user-images.githubusercontent.com/5920286/153053224-043f7597-90b5-49c9-9b3f-b380e4ee9a97.png)
