### PR TITLE
gitignore: Add webrtc html adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /src/html/vue.js
+/src/html/webrtc/adapter
 /target
 **/*.rs.bk


### PR DESCRIPTION
Necessary since the files are downloaded during our build step

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>