### PR TITLE
Cargo: Update tokio to 1.19, fixing vulnerability.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1614,7 +1614,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 1.17.0",
+ "tokio 1.19.2",
  "tokio-util 0.7.1",
  "tracing",
 ]
@@ -1718,7 +1718,7 @@ dependencies = [
  "itoa 1.0.1",
  "pin-project-lite 0.2.8",
  "socket2 0.4.4",
- "tokio 1.17.0",
+ "tokio 1.19.2",
  "tower-service",
  "tracing",
  "want",
@@ -1733,7 +1733,7 @@ dependencies = [
  "bytes 1.1.0",
  "hyper",
  "native-tls",
- "tokio 1.17.0",
+ "tokio 1.19.2",
  "tokio-native-tls",
 ]
 
@@ -2059,7 +2059,7 @@ dependencies = [
  "serde_json",
  "simple-error",
  "sys-info",
- "tokio 1.17.0",
+ "tokio 1.19.2",
  "turn",
  "url",
  "v4l",
@@ -2942,7 +2942,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 1.17.0",
+ "tokio 1.19.2",
  "tokio-native-tls",
  "url",
  "wasm-bindgen",
@@ -3407,7 +3407,7 @@ dependencies = [
  "ring",
  "subtle",
  "thiserror",
- "tokio 1.17.0",
+ "tokio 1.19.2",
  "url",
  "webrtc-util",
 ]
@@ -3634,9 +3634,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.17.0"
+version = "1.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
+checksum = "c51a52ed6686dd62c320f9b89299e9dfb46f730c7a48e635c19f21d116cb1439"
 dependencies = [
  "bytes 1.1.0",
  "libc",
@@ -3670,7 +3670,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
- "tokio 1.17.0",
+ "tokio 1.19.2",
 ]
 
 [[package]]
@@ -3697,7 +3697,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project-lite 0.2.8",
- "tokio 1.17.0",
+ "tokio 1.19.2",
  "tracing",
 ]
 
@@ -3868,7 +3868,7 @@ dependencies = [
  "ring",
  "stun",
  "thiserror",
- "tokio 1.17.0",
+ "tokio 1.19.2",
  "webrtc-util",
 ]
 
@@ -4202,7 +4202,7 @@ dependencies = [
  "parking_lot 0.11.2",
  "rand 0.8.5",
  "thiserror",
- "tokio 1.17.0",
+ "tokio 1.19.2",
  "winapi 0.3.9",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ gstreamer-rtsp-server = { version = "0.18.0", optional = true }
 anyhow = "1"
 async-std = "1"
 async-native-tls = "0.4"
-tokio = "1.17"
+tokio = "1.19"
 turn = "0.5"
 util = { package = "webrtc-util", version = "0.5", default-features = false, features = ["vnet"] }
 webrtcsink-signalling = { version = "0.1.0", git = "https://github.com/centricular/webrtcsink", rev = "2c855b9cfe1cf10c7447aa6ca5e3d5444e2459e0" }


### PR DESCRIPTION
fixes: https://github.com/joaoantoniocardoso/mavlink-camera-manager/security/dependabot/2