### PR TITLE
Add rpicamera support

### DIFF
--- a/src/stream/gst/pipeline_builder.rs
+++ b/src/stream/gst/pipeline_builder.rs
@@ -88,7 +88,24 @@ impl Pipeline {
                 }
             },
             VideoSourceType::Local(local_device) => {
-                format!("v4l2src device={}", &local_device.device_path)
+                match &local_device.typ {
+                    crate::video::video_source_local::VideoSourceLocalType::Usb(_) => {
+                        format!("v4l2src device={}", &local_device.device_path)
+                    }
+                    // For raspberry pi cameras (in Legacy Mode), rpicamsrc
+                    // is used to be used insted v4l2src as a workaround to
+                    // prevent Kernel Oops caused by setting a unsupported but
+                    // wrongly stated as supported by v4l2 Frame Size and/or
+                    // FPS.
+                    crate::video::video_source_local::VideoSourceLocalType::LegacyRpiCam(_) => {
+                        format!("rpicamsrc camera-number=0")
+                    }
+                    typ => {
+                        return Err(SimpleError::new(format!(
+                            "Unsuported VideoSourceLocal: {typ:#?}."
+                        )))
+                    }
+                }
             }
             video_source_type => {
                 return Err(SimpleError::new(format!(

--- a/src/stream/stream_backend.rs
+++ b/src/stream/stream_backend.rs
@@ -338,7 +338,7 @@ mod tests {
             video_source: VideoSourceType::Local(VideoSourceLocal {
                 name: "PotatoCam".into(),
                 device_path: "/dev/video42".into(),
-                typ: VideoSourceLocalType::Unknown("TestPotatoCam".into()),
+                typ: VideoSourceLocalType::Usb("TestPotatoCam".into()),
             }),
         });
 

--- a/src/video/video_source_local.rs
+++ b/src/video/video_source_local.rs
@@ -18,7 +18,7 @@ use log::*;
 pub enum VideoSourceLocalType {
     Unknown(String),
     Usb(String),
-    V4l2(String),
+    LegacyRpiCam(String),
 }
 
 #[derive(Apiv2Schema, Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -71,7 +71,7 @@ impl VideoSourceLocalType {
     fn v4l2_from_str(description: &str) -> Option<Self> {
         let regex = Regex::new(r"platform:(?P<device>\S+)-v4l2-[0-9]").unwrap();
         if regex.is_match(description) {
-            return Some(VideoSourceLocalType::V4l2(description.into()));
+            return Some(VideoSourceLocalType::LegacyRpiCam(description.into()));
         }
         return None;
     }
@@ -474,8 +474,8 @@ mod tests {
                 "usb-3f980000.usb-1.4",
             ),
             (
-                // Provided by the raspberry pi with a libcamera device (using the v4l2 compatibility layer)
-                VideoSourceLocalType::V4l2("platform:bcm2835-v4l2-0".into()),
+                // Provided by the raspberry pi with a Raspberry Pi camera when in to use legacy camera mode
+                VideoSourceLocalType::LegacyRpiCam("platform:bcm2835-v4l2-0".into()),
                 "platform:bcm2835-v4l2-0",
             ),
             (


### PR DESCRIPTION
Closes #66.

Finally, with this PR, Raspberry Pi Camera will be working, but with the following notes:
- Only Legacy Camera mode is supported, to do so, one needs to enable it using `raspi-config`, which can be done in one line: ` if [[ $(raspi-config nonint get_legacy) == 1 ]]; then sudo raspi-config nonint do_legacy 0 && sudo sync && sudo reboot; fi `
- Any Raspberry Pi Camera will be constrained to work with a maximum resolution of 1920 x 1080 px, and/or with a maximum frame rate of 30 FPS.
- rpicam needs to be added into the GStreamer build to have the `rpicamsrc` plugin available.