### PR TITLE
src: stream: Make the old settings compatible.

### DIFF
--- a/src/stream/types.rs
+++ b/src/stream/types.rs
@@ -50,10 +50,11 @@ pub struct VideoCaptureConfiguration {
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
 pub struct RedirectCaptureConfiguration {}
 
 #[derive(Apiv2Schema, Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(tag = "type", rename_all = "lowercase")]
+#[serde(untagged, rename_all = "lowercase")]
 pub enum CaptureConfiguration {
     VIDEO(VideoCaptureConfiguration),
     REDIRECT(RedirectCaptureConfiguration),


### PR DESCRIPTION
Turns out that we can make the tag "type" as optional for VideoCaptureConfiguration ("type": "video"), but required for any other, like RedirectCaptureConfiguration ("type": "redirect").

Fixes #81.