### PR TITLE
src: mavlink: Heartbeat should use MAV_AUTOPILOT_INVALID.

### DIFF
--- a/src/mavlink/mavlink_camera.rs
+++ b/src/mavlink/mavlink_camera.rs
@@ -715,7 +715,7 @@ fn heartbeat_message() -> mavlink::common::MavMessage {
     mavlink::common::MavMessage::HEARTBEAT(mavlink::common::HEARTBEAT_DATA {
         custom_mode: 0,
         mavtype: mavlink::common::MavType::MAV_TYPE_CAMERA,
-        autopilot: mavlink::common::MavAutopilot::MAV_AUTOPILOT_GENERIC,
+        autopilot: mavlink::common::MavAutopilot::MAV_AUTOPILOT_INVALID,
         base_mode: mavlink::common::MavModeFlag::empty(),
         system_status: mavlink::common::MavState::MAV_STATE_STANDBY,
         mavlink_version: 0x3,


### PR DESCRIPTION
"Use MAV_AUTOPILOT_INVALID for components that are not flight
controllers." (https://mavlink.io/en/messages/common.html#HEARTBEAT)

Fixes #105.