### PR TITLE
src: stream: Allow any IP for RTSP streams.

### DIFF
--- a/src/stream/stream_backend.rs
+++ b/src/stream/stream_backend.rs
@@ -173,12 +173,6 @@ fn create_rtsp_stream(
             endpoint.scheme()
         )));
     }
-    if endpoint.host_str() != "0.0.0.0".into() {
-        return Err(simple_error!(format!(
-            "The URL's host for RTSP endpoints should be \"0.0.0.0\", but was: {:?}",
-            endpoint.host_str()
-        )));
-    }
     if endpoint.port() != Some(8554) {
         return Err(simple_error!(format!(
             "The URL's port for RTSP endpoints should be \"8554\", but was: {:?}",


### PR DESCRIPTION
Now that we are advertising via MAVLink with the same IP as the stream endpoint, we should allow the use of the local IP for RTSP (like `192.168.2.2`) instead of restricting it to `0.0.0.0`, so QGC can connect to it using the advertised IP, otherwise, QGC would be trying to connect to `0.0.0.0`, which will fail if the RTSP server and QGC are not both under the same localhost.

This solves the bug related to #114, but that issue should be kept open for further discussion over automatic IP.