### PR TITLE
stream: manager: Do not crete streams if vector is empty

### DIFF
--- a/src/settings/manager.rs
+++ b/src/settings/manager.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use crate::cli;
+use crate::custom;
 use crate::video_stream::types::VideoAndStreamInformation;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -43,26 +44,7 @@ impl Default for SettingsStruct {
                 version: 0,
             },
             mavlink_endpoint: None,
-            streams: vec![/*VideoAndStreamInformation {
-                name: "Test".into(),
-                stream_information: StreamInformation {
-                    endpoints: vec![Url::parse("udp://0.0.0.0:5601").unwrap()],
-                    configuration: CaptureConfiguration {
-                        encode: VideoEncodeType::H264,
-                        height: 720,
-                        width: 1080,
-                        frame_interval: FrameInterval {
-                            numerator: 1,
-                            denominator: 30,
-                        },
-                    },
-                },
-                video_source: VideoSourceType::Local(VideoSourceLocal {
-                    name: "Camera Manager Default Camera".into(),
-                    device_path: "/dev/video0".into(),
-                    typ: VideoSourceLocalType::Usb("0000:08:00.3-1".into()),
-                }),
-            }*/],
+            streams: custom::create_default_streams(),
         }
     }
 }

--- a/src/stream/manager.rs
+++ b/src/stream/manager.rs
@@ -1,6 +1,5 @@
 use super::types::*;
 use super::{stream_backend, stream_backend::StreamBackend};
-use crate::custom;
 use crate::mavlink::mavlink_camera::MavlinkCameraHandle;
 use crate::settings;
 use crate::video::types::VideoSourceType;
@@ -50,10 +49,6 @@ pub fn start_default() {
     MANAGER.as_ref().lock().unwrap().streams.clear();
 
     let mut streams = settings::manager::streams();
-
-    if streams.is_empty() {
-        streams = custom::create_default_streams();
-    }
 
     // Update all local video sources to make sure that is available
     streams.iter_mut().for_each(|stream| {


### PR DESCRIPTION
Only do that if the settings does not exist, or the user force the reset

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>