### PR TITLE
cargo: Upgrade vergen 7.4.1, remove enum-iterator workaround.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1796,7 +1796,6 @@ dependencies = [
  "chrono",
  "clap 2.34.0",
  "directories",
- "enum-iterator",
  "glib",
  "gstreamer",
  "gstreamer-rtsp-server",
@@ -3381,9 +3380,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vergen"
-version = "7.4.0"
+version = "7.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffa80ed519f45995741e70664d4abcf147d2a47b8c7ea0a4aa495548ef9474f"
+checksum = "83d00118b08fb5c40b58177a494dfc8a34b43ba0757938e98e87ed11b9c58485"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,8 +74,7 @@ rand = "0.8.5"
 
 [build-dependencies]
 reqwest = { version = "0.11.11", features = ["blocking"] }
-vergen = { version = "7.3.1", default-features = false, features = ["build", "git"] }
-enum-iterator = "~1.1.3" # `enum-iterator` is a dependency for `vergen`, but because `v1.2.0` is causing the `error[E0658]`, we are restricting its version by defining it as `~1.1.3` here.
+vergen = { version = "7.4.1", default-features = false, features = ["build", "git"] }
 
 [features]
 default = ["rtsp"]


### PR DESCRIPTION
The workaround is described in the previous commit: cef5990d3040f76a20a11282aaa97034b39af89e