### PR TITLE
Create ROV RTSP default settings

### DIFF
--- a/src/cli/manager.rs
+++ b/src/cli/manager.rs
@@ -69,6 +69,10 @@ pub fn server_address() -> &'static str {
         .unwrap();
 }
 
+pub fn vehicle_ddns() -> Option<&'static str> {
+    MANAGER.as_ref().clap_matches.value_of("vehicle-ddns")
+}
+
 pub fn www_path() -> Option<&'static str> {
     if let Some(argument_www_path) = MANAGER.as_ref().clap_matches.value_of("www-path") {
         if std::path::Path::new(&format!("{argument_www_path}/webrtc/adapter")).exists() {
@@ -229,6 +233,12 @@ fn get_clap_matches<'a>() -> clap::ArgMatches<'a> {
                 .long("log-path")
                 .help("Specifies the path in witch the logs will be stored.")
                 .default_value("./logs")
+                .takes_value(true),
+        )
+        .arg(
+            clap::Arg::with_name("vehicle-ddns")
+                .long("vehicle-ddns")
+                .help("Specifies the Dynamic DNS to use as vehicle IP when advertising streams via mavlink.")
                 .takes_value(true),
         );
 

--- a/src/custom/bluerov.rs
+++ b/src/custom/bluerov.rs
@@ -1,5 +1,6 @@
 use url::Url;
 
+use crate::network::utils::get_visible_qgc_address;
 use crate::stream::types::*;
 use crate::video::{self, types::*, video_source::VideoSourceAvailable};
 use crate::video_stream::types::VideoAndStreamInformation;
@@ -35,6 +36,54 @@ pub fn udp() -> Vec<VideoAndStreamInformation> {
                     endpoints: vec![
                         Url::parse(&format!("udp://192.168.2.1:{}", 5600 + index)).unwrap()
                     ],
+                    configuration: CaptureConfiguration::VIDEO(VideoCaptureConfiguration {
+                        encode: format.encode.clone(),
+                        height: size.height,
+                        width: size.width,
+                        frame_interval: size.intervals.first().unwrap().clone(),
+                    }),
+                    extended_configuration: None,
+                },
+                video_source: cam.clone(),
+            }
+        })
+        .collect()
+}
+
+pub fn rtsp() -> Vec<VideoAndStreamInformation> {
+    video::video_source_local::VideoSourceLocal::cameras_available()
+        .iter()
+        .filter(|cam| {
+            cam.inner()
+                .formats()
+                .iter()
+                .any(|format| format.encode == VideoEncodeType::H264)
+        })
+        .enumerate()
+        .map(|(index, cam)| {
+            let formats = cam.inner().formats();
+            let format = formats
+                .iter()
+                .find(|format| format.encode == VideoEncodeType::H264)
+                .unwrap();
+
+            // Get the biggest resolution possible
+            let mut sizes = format.sizes.clone();
+            sizes.sort_by(|first_size, second_size| {
+                (10 * first_size.width + first_size.height)
+                    .cmp(&(10 * second_size.width + second_size.height))
+            });
+            let size = sizes.last().unwrap();
+
+            let visible_qgc_ip_address = get_visible_qgc_address().to_string();
+
+            VideoAndStreamInformation {
+                name: format!("RTSP Stream {index}"),
+                stream_information: StreamInformation {
+                    endpoints: vec![Url::parse(&format!(
+                        "rtsp://{visible_qgc_ip_address}:8554/video_{index}"
+                    ))
+                    .unwrap()],
                     configuration: CaptureConfiguration::VIDEO(VideoCaptureConfiguration {
                         encode: format.encode.clone(),
                         height: size.height,

--- a/src/custom/mod.rs
+++ b/src/custom/mod.rs
@@ -11,6 +11,7 @@ arg_enum! {
     #[derive(PartialEq, Debug)]
     pub enum CustomEnvironment {
         BlueROVUDP,
+        BlueROVRTSP,
     }
 }
 
@@ -24,5 +25,6 @@ pub fn create_default_streams() -> Vec<VideoAndStreamInformation> {
 
     match default_environment {
         CustomEnvironment::BlueROVUDP => bluerov::udp(),
+        CustomEnvironment::BlueROVRTSP => bluerov::rtsp(),
     }
 }

--- a/src/mavlink/mavlink_camera.rs
+++ b/src/mavlink/mavlink_camera.rs
@@ -1,5 +1,5 @@
 use crate::cli;
-use crate::network;
+use crate::network::utils::get_visible_qgc_address;
 use crate::settings;
 use crate::stream::types::StreamType;
 use crate::video::types::VideoSourceType;
@@ -221,10 +221,7 @@ impl MavlinkCameraInformation {
         // change between the time of the MavlinkCameraInformation creation
         // and the time MAVLink connection is negotiated with the other MAVLink
         // systems.
-        let visible_qgc_ip_address = network::utils::get_ipv4_addresses()
-            .last()
-            .unwrap_or(&std::net::Ipv4Addr::UNSPECIFIED)
-            .to_string();
+        let visible_qgc_ip_address = get_visible_qgc_address().to_string();
         let server_port = cli::manager::server_address()
             .split(':')
             .collect::<Vec<&str>>()[1];

--- a/src/network/utils.rs
+++ b/src/network/utils.rs
@@ -1,6 +1,18 @@
 use pnet;
 use tracing::*;
 
+use crate::cli::manager::vehicle_ddns;
+
+pub fn get_visible_qgc_address() -> String {
+    match vehicle_ddns() {
+        Some(ddns) => ddns.to_string(),
+        None => get_ipv4_addresses()
+            .last()
+            .unwrap_or(&std::net::Ipv4Addr::UNSPECIFIED)
+            .to_string(),
+    }
+}
+
 pub fn get_ipv4_addresses() -> Vec<std::net::Ipv4Addr> {
     // Start with 0.0.0.0
     let mut ips = vec![std::net::Ipv4Addr::UNSPECIFIED];


### PR DESCRIPTION
- [x] Tested on Raspberry Pi

This patch enhances our support for DHCP setups by:
1. Allowing the use of a Dynamic DNS, configured via CLI argument, to be used as the URI for the Mavlink camera XML file, as well in the RTSP stream URI, instead of directly using the local IP.
2. Allowing the creation of RTSP streams by default, opt-in via CLI argument.

---

Example:

![image](https://user-images.githubusercontent.com/5920286/188971583-c7879765-df5a-4660-b900-d5e7f28f3e3e.png)
