### PR TITLE
src: stream:  Disable RTSP + UDP endpoints creation

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -54,6 +54,16 @@ impl Stream {
 
         let endpoints = &video_and_stream_information.stream_information.endpoints;
 
+        // Disable concurrent RTSP and UDP sinks creation, as it is failing.
+        // TODO: Enable this and investigate why it is failing when we try to create RTSP+UDP: "rtsp://0.0.0.0:8554/test, udp://localhost:5600"
+        if endpoints.iter().any(|endpoint| endpoint.scheme() == "udp")
+            && endpoints.iter().any(|endpoint| endpoint.scheme() == "rtsp")
+        {
+            return Err(anyhow!(
+                "UDP endpoints won't work together with RTSP endpoints. You need to choose one. This is a (temporary) software limitation, if this is a feature you need, please, contact us."
+            ));
+        }
+
         if endpoints.iter().any(|endpoint| endpoint.scheme() == "udp") {
             if let Err(reason) =
                 create_udp_sink(Manager::generate_uuid(), video_and_stream_information)


### PR DESCRIPTION
This acts as a workaround that (temporarily) closes #161, prioritizing the stability for an earlier release.