### PR TITLE
src: stream: Add more log, skip unneeded information

### DIFF
--- a/src/stream/manager.rs
+++ b/src/stream/manager.rs
@@ -45,6 +45,7 @@ lazy_static! {
 }
 
 impl Manager {
+    #[instrument(level = "debug", skip(self))]
     fn update_settings(&self) {
         let video_and_stream_informations = self
             .streams

--- a/src/stream/pipeline/fake_pipeline.rs
+++ b/src/stream/pipeline/fake_pipeline.rs
@@ -13,6 +13,8 @@ use super::{
 
 use anyhow::{anyhow, Result};
 
+use tracing::*;
+
 use gst::prelude::*;
 
 #[derive(Debug)]
@@ -21,6 +23,7 @@ pub struct FakePipeline {
 }
 
 impl FakePipeline {
+    #[instrument(level = "debug")]
     pub fn try_new(
         pipeline_id: uuid::Uuid,
         video_and_stream_information: &VideoAndStreamInformation,
@@ -141,6 +144,7 @@ impl FakePipeline {
 }
 
 impl PipelineGstreamerInterface for FakePipeline {
+    #[instrument(level = "trace")]
     fn is_running(&self) -> bool {
         self.state.pipeline_runner.is_running()
     }

--- a/src/stream/pipeline/mod.rs
+++ b/src/stream/pipeline/mod.rs
@@ -9,9 +9,9 @@ use enum_dispatch::enum_dispatch;
 
 use anyhow::{anyhow, Context, Result};
 
-use gst::prelude::*;
-
 use tracing::*;
+
+use gst::prelude::*;
 
 use crate::{
     stream::{
@@ -76,13 +76,13 @@ impl Pipeline {
         })
     }
 
-    #[instrument(level = "debug")]
+    #[instrument(level = "debug", skip(self))]
     pub fn add_sink(&mut self, sink: Sink) -> Result<()> {
         self.inner_state_mut().add_sink(sink)
     }
 
     #[allow(dead_code)] // This functions is reserved here for when we start dynamically add/remove Sinks
-    #[instrument(level = "debug")]
+    #[instrument(level = "debug", skip(self))]
     pub fn remove_sink(&mut self, sink_id: &uuid::Uuid) -> Result<()> {
         self.inner_state_mut().remove_sink(sink_id)
     }
@@ -154,7 +154,7 @@ impl PipelineState {
     }
 
     /// Links the sink pad from the given Sink to this Pipeline's Tee element
-    #[instrument(level = "debug")]
+    #[instrument(level = "debug", skip(self))]
     pub fn add_sink(&mut self, mut sink: Sink) -> Result<()> {
         let pipeline_id = &self.pipeline_id;
 
@@ -225,7 +225,7 @@ impl PipelineState {
     /// Unlinks the src pad from this Sink from the given sink pad of a Tee element
     ///
     /// Important notes about pad unlinking: [here](https://gstreamer.freedesktop.org/documentation/application-development/advanced/pipeline-manipulation.html?gi-language=c#dynamically-changing-the-pipeline)
-    #[instrument(level = "info")]
+    #[instrument(level = "info", skip(self))]
     pub fn remove_sink(&mut self, sink_id: &uuid::Uuid) -> Result<()> {
         let pipeline_id = &self.pipeline_id;
         let sink = self.sinks.remove(sink_id).context(format!(

--- a/src/stream/pipeline/redirect_pipeline.rs
+++ b/src/stream/pipeline/redirect_pipeline.rs
@@ -7,6 +7,8 @@ use super::{PipelineGstreamerInterface, PipelineState, PIPELINE_SINK_TEE_NAME};
 
 use anyhow::{anyhow, Context, Result};
 
+use tracing::*;
+
 use gst::prelude::*;
 
 #[derive(Debug)]
@@ -15,6 +17,7 @@ pub struct RedirectPipeline {
 }
 
 impl RedirectPipeline {
+    #[instrument(level = "debug")]
     pub fn try_new(
         pipeline_id: uuid::Uuid,
         video_and_stream_information: &VideoAndStreamInformation,
@@ -96,6 +99,7 @@ impl RedirectPipeline {
 }
 
 impl PipelineGstreamerInterface for RedirectPipeline {
+    #[instrument(level = "trace")]
     fn is_running(&self) -> bool {
         self.state.pipeline_runner.is_running()
     }

--- a/src/stream/pipeline/runner.rs
+++ b/src/stream/pipeline/runner.rs
@@ -52,12 +52,12 @@ impl PipelineRunner {
         })
     }
 
-    #[instrument(level = "debug")]
+    #[instrument(level = "debug", skip(self))]
     pub fn get_receiver(&self) -> broadcast::Receiver<String> {
         self.killswitch_sender.subscribe()
     }
 
-    #[instrument(level = "debug")]
+    #[instrument(level = "debug", skip(self))]
     pub fn is_running(&self) -> bool {
         !self._watcher_thread_handle.is_finished()
     }
@@ -181,7 +181,7 @@ impl PipelineRunner {
 }
 
 impl Drop for PipelineRunner {
-    #[instrument(level = "debug")]
+    #[instrument(level = "debug", skip(self))]
     fn drop(&mut self) {
         if let Err(reason) = self
             .killswitch_sender

--- a/src/stream/pipeline/v4l_pipeline.rs
+++ b/src/stream/pipeline/v4l_pipeline.rs
@@ -132,6 +132,7 @@ impl V4lPipeline {
 }
 
 impl PipelineGstreamerInterface for V4lPipeline {
+    #[instrument(level = "trace")]
     fn is_running(&self) -> bool {
         self.state.pipeline_runner.is_running()
     }

--- a/src/stream/sink/image_sink.rs
+++ b/src/stream/sink/image_sink.rs
@@ -2,8 +2,9 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::{anyhow, Context, Result};
 
-use image::FlatSamples;
 use tracing::*;
+
+use image::FlatSamples;
 
 use gst::prelude::*;
 
@@ -20,7 +21,7 @@ pub struct ImageSink {
     flat_samples: Arc<Mutex<Option<FlatSamples<Vec<u8>>>>>,
 }
 impl SinkInterface for ImageSink {
-    #[instrument(level = "debug")]
+    #[instrument(level = "debug", skip(self))]
     fn link(
         &mut self,
         pipeline: &gst::Pipeline,
@@ -82,7 +83,7 @@ impl SinkInterface for ImageSink {
         Ok(())
     }
 
-    #[instrument(level = "debug")]
+    #[instrument(level = "debug", skip(self))]
     fn unlink(&self, pipeline: &gst::Pipeline, pipeline_id: &uuid::Uuid) -> Result<()> {
         let sink_id = self.get_id();
 
@@ -135,11 +136,12 @@ impl SinkInterface for ImageSink {
         Ok(())
     }
 
-    #[instrument(level = "debug")]
+    #[instrument(level = "debug", skip(self))]
     fn get_id(&self) -> uuid::Uuid {
         self.sink_id
     }
 
+    #[instrument(level = "trace", skip(self))]
     fn get_sdp(&self) -> Result<gst_sdp::SDPMessage> {
         Err(anyhow!(
             "Not available. Reason: Image Sink doesn't provide endpoints"
@@ -148,6 +150,7 @@ impl SinkInterface for ImageSink {
 }
 
 impl ImageSink {
+    #[instrument(level = "debug")]
     pub fn try_new(id: uuid::Uuid, encoding: VideoEncodeType) -> Result<Self> {
         let queue = gst::ElementFactory::make("queue")
             .property_from_str("leaky", "downstream") // Throw away any data
@@ -288,6 +291,7 @@ impl ImageSink {
         })
     }
 
+    #[instrument(level = "debug", skip(self))]
     pub fn make_jpeg_thumbnail_from_last_frame(
         &self,
         quality: u8,

--- a/src/stream/sink/mod.rs
+++ b/src/stream/sink/mod.rs
@@ -75,6 +75,7 @@ pub fn create_rtsp_sink(
     Ok(Sink::Rtsp(RtspSink::try_new(id, addresses)?))
 }
 
+#[instrument(level = "debug")]
 pub fn create_image_sink(
     id: uuid::Uuid,
     video_and_stream_information: &VideoAndStreamInformation,

--- a/src/stream/sink/rtsp_sink.rs
+++ b/src/stream/sink/rtsp_sink.rs
@@ -18,7 +18,7 @@ pub struct RtspSink {
     socket_path: String,
 }
 impl SinkInterface for RtspSink {
-    #[instrument(level = "debug")]
+    #[instrument(level = "debug", skip(self))]
     fn link(
         &mut self,
         pipeline: &gst::Pipeline,
@@ -72,7 +72,7 @@ impl SinkInterface for RtspSink {
         Ok(())
     }
 
-    #[instrument(level = "debug")]
+    #[instrument(level = "debug", skip(self))]
     fn unlink(&self, pipeline: &gst::Pipeline, pipeline_id: &uuid::Uuid) -> Result<()> {
         let sink_id = self.get_id();
 
@@ -122,12 +122,12 @@ impl SinkInterface for RtspSink {
         Ok(())
     }
 
-    #[instrument(level = "debug")]
+    #[instrument(level = "debug", skip(self))]
     fn get_id(&self) -> uuid::Uuid {
         self.sink_id
     }
 
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(self))]
     fn get_sdp(&self) -> Result<gst_sdp::SDPMessage> {
         Err(anyhow!(
             "Not available. Reason: RTSP Sink should only be connected from its RTSP endpoint."
@@ -172,12 +172,12 @@ impl RtspSink {
         })
     }
 
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(self))]
     pub fn path(&self) -> String {
         self.path.clone()
     }
 
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(self))]
     pub fn socket_path(&self) -> String {
         self.socket_path.clone()
     }

--- a/src/stream/sink/udp_sink.rs
+++ b/src/stream/sink/udp_sink.rs
@@ -17,7 +17,7 @@ pub struct UdpSink {
     addresses: Vec<url::Url>,
 }
 impl SinkInterface for UdpSink {
-    #[instrument(level = "debug")]
+    #[instrument(level = "debug", skip(self))]
     fn link(
         &mut self,
         pipeline: &gst::Pipeline,
@@ -69,7 +69,7 @@ impl SinkInterface for UdpSink {
         Ok(())
     }
 
-    #[instrument(level = "debug")]
+    #[instrument(level = "debug", skip(self))]
     fn unlink(&self, pipeline: &gst::Pipeline, pipeline_id: &uuid::Uuid) -> Result<()> {
         let sink_id = self.get_id();
 
@@ -115,11 +115,12 @@ impl SinkInterface for UdpSink {
         Ok(())
     }
 
-    #[instrument(level = "debug")]
+    #[instrument(level = "debug", skip(self))]
     fn get_id(&self) -> uuid::Uuid {
         self.sink_id
     }
 
+    #[instrument(level = "debug", skip(self))]
     fn get_sdp(&self) -> Result<gst_sdp::SDPMessage> {
         let caps = self
             .udpsink_sink_pad

--- a/src/stream/webrtc/signalling_server.rs
+++ b/src/stream/webrtc/signalling_server.rs
@@ -372,7 +372,7 @@ impl TryFrom<tungstenite::Message> for signalling_protocol::Protocol {
 impl TryInto<tungstenite::Message> for signalling_protocol::Protocol {
     type Error = anyhow::Error;
 
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip(self))]
     fn try_into(self) -> Result<tungstenite::Message, Self::Error> {
         let json_str = serde_json::to_string(&self)?;
 


### PR DESCRIPTION
Logging `self` is not useful and can freeze when the object has big arrays.