### PR TITLE
cargo, src: Integrate GStreamer logs into Tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2108,6 +2108,7 @@ dependencies = [
  "tracing",
  "tracing-actix-web",
  "tracing-appender",
+ "tracing-gstreamer",
  "tracing-log",
  "tracing-subscriber",
  "tracing-test",
@@ -3562,6 +3563,20 @@ checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-gstreamer"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e2f5446459d0c88134d40fb74a76f95343ac332db9c0085104a4d1c9926b0b"
+dependencies = [
+ "gstreamer",
+ "libc",
+ "once_cell",
+ "thread_local",
+ "tracing",
+ "tracing-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 tracing-log = "0.1.3"
 tracing-appender = "0.2.2"
 tracing-actix-web = "0.6.0"
+tracing-gstreamer = "0.4.0"
 anyhow = "1"
 tokio = { version = "1.21", features = ["full"] }
 enum_dispatch = "0.3.8"

--- a/src/logger/manager.rs
+++ b/src/logger/manager.rs
@@ -48,6 +48,10 @@ pub fn init() {
         .with(file_layer);
     tracing::subscriber::set_global_default(subscriber).expect("Unable to set a global subscriber");
 
+    // Redirects all gstreamer logs to tracing.
+    tracing_gstreamer::integrate_events(); // This must be called before any gst::init()
+    gst::debug_remove_default_log_function();
+
     info!(
         "{}, version: {}-{}, build date: {}",
         env!("CARGO_PKG_NAME"),


### PR DESCRIPTION
Without integrate_spans() because it would significantly change the format of the GST logs we are already used to, also difficulting web search.