### PR TITLE
Disable tracy by default

### DIFF
--- a/src/cli/manager.rs
+++ b/src/cli/manager.rs
@@ -51,6 +51,10 @@ pub fn is_reset() -> bool {
     return MANAGER.as_ref().clap_matches.is_present("reset");
 }
 
+pub fn is_tracy() -> bool {
+    return MANAGER.as_ref().clap_matches.is_present("enable-tracy");
+}
+
 #[allow(dead_code)]
 // Return the mavlink connection string
 pub fn mavlink_connection_string() -> Option<&'static str> {
@@ -204,6 +208,12 @@ fn get_clap_matches<'a>() -> clap::ArgMatches<'a> {
                 .long("vehicle-ddns")
                 .help("Specifies the Dynamic DNS to use as vehicle IP when advertising streams via mavlink.")
                 .takes_value(true),
+        )
+        .arg(
+            clap::Arg::with_name("enable-tracy")
+                .long("enable-tracy")
+                .help("Turns on the Tracy tool integration. Learn more: https://github.com/wolfpld/tracy")
+                .takes_value(false),
         );
 
     matches.get_matches()

--- a/src/logger/manager.rs
+++ b/src/logger/manager.rs
@@ -47,15 +47,25 @@ pub fn init() {
         .with_thread_names(true)
         .with_filter(file_env_filter);
 
-    // Configure tracing to tracy
-    let tracy_layer = tracing_tracy::TracyLayer::new();
-
     // Configure the default subscriber
-    let subscriber = tracing_subscriber::registry()
-        .with(console_layer)
-        .with(file_layer)
-        .with(tracy_layer);
-    tracing::subscriber::set_global_default(subscriber).expect("Unable to set a global subscriber");
+    match cli::manager::is_tracy() {
+        true => {
+            let tracy_layer = tracing_tracy::TracyLayer::new();
+            let subscriber = tracing_subscriber::registry()
+                .with(console_layer)
+                .with(file_layer)
+                .with(tracy_layer);
+            tracing::subscriber::set_global_default(subscriber)
+                .expect("Unable to set a global subscriber");
+        }
+        false => {
+            let subscriber = tracing_subscriber::registry()
+                .with(console_layer)
+                .with(file_layer);
+            tracing::subscriber::set_global_default(subscriber)
+                .expect("Unable to set a global subscriber");
+        }
+    };
 
     // Redirects all gstreamer logs to tracing.
     tracing_gstreamer::integrate_events(); // This must be called before any gst::init()


### PR DESCRIPTION
Although Tracy is super useful, it's only useful for development and it adds some overhead even when not being used, so I'll keep it disabled by default.