### PR TITLE
Fix rtsp static rtsp sink

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -96,6 +96,13 @@ impl Stream {
             ));
         }
 
+        // Start the pipeline. This will automatically start sinks with linked proxy-isolated pipelines
+        stream
+            .pipeline
+            .inner_state_as_ref()
+            .pipeline_runner
+            .start()?;
+
         Ok(stream)
     }
 }


### PR DESCRIPTION
Fixes #210 by connecting sinks before starting the pipeline.

Don't merge it yet as I'm still testing all cases.

Tests:
- [x] RTSP h264 1080p 30fps + with multiple WebRTC clients
- [x] UDP h264 1080p 30fps + with multiple WebRTC clients
- [x] stress streams creation
- [x] stress thumbnails
- [x] RTSP with other encodings, sizes and fpss
- [x] UDP with other encodings, sizes and fpss
