### PR TITLE
Reduce UDP latency

### DIFF
--- a/src/stream/sink/udp_sink.rs
+++ b/src/stream/sink/udp_sink.rs
@@ -299,7 +299,7 @@ impl UdpSink {
             })
             .collect::<Vec<String>>()
             .join(",");
-        let description = format!("multiudpsink clients={clients}");
+        let description = format!("multiudpsink sync=false clients={clients}");
         let _udpsink =
             gst::parse_launch(&description).context("Failed parsing pipeline description")?;
 


### PR DESCRIPTION
This reduces latency by sending packages as soon as the frames arrive, without waiting the theoretical FPS period.

Before: 192ms avg
After: 128ms avg